### PR TITLE
CI-1009 Update test for website link check

### DIFF
--- a/src/Esfa.Roaao.Xslx.IntegrationTests/RoaaoExcelTests.cs
+++ b/src/Esfa.Roaao.Xslx.IntegrationTests/RoaaoExcelTests.cs
@@ -8,6 +8,8 @@ using System;
 using System.Configuration;
 using System.Net.Http;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using Sfa.Das.Sas.Indexer.ApplicationServices.Shared.Settings;
 
 namespace Esfa.Roaao.Xslx.IntegrationTests
@@ -199,25 +201,30 @@ namespace Esfa.Roaao.Xslx.IntegrationTests
 
         [TestMethod]
         [TestCategory("RoAAo Excel Tests")]
-        public void ShouldNotHaveBrokenWebsiteLink()
+        public async Task ShouldNotHaveBrokenWebsiteLink()
         {
             var errors = new List<string>();
             foreach (var epa in results.Organisations.Select(x => new string[] { x.EpaOrganisationIdentifier, x.WebsiteLink }))
             {
                 var website = epa[1];
-                var websiteCheck = CheckWebsiteLink(website);
-                if (!string.IsNullOrEmpty(website) && !websiteCheck.Key)
+                if (!string.IsNullOrEmpty(website))
                 {
-                    errors.Add($"{epa[0]} EPA Org has a broken website link {epa[1]}, no of attempts {websiteCheck.Value}");
+                    var websiteCheck = await CheckWebsiteLink(website);
+                    if (!websiteCheck.Key)
+                    {
+                        errors.Add($"{epa[0]} EPA Org has a broken website link {epa[1]}, no of attempts {websiteCheck.Value}");
+                    }
                 }
+                
             }
             Assert.IsTrue(errors.Count == 0, string.Join(Environment.NewLine, errors));
         }
 
-        private KeyValuePair<bool, int> CheckWebsiteLink(string website)
+        private async Task<KeyValuePair<bool, string>> CheckWebsiteLink(string website)
         {
             var absolutePath = website.StartsWith("http") ? website : $"http://{website}";
             int noofattempts = 0;
+            var responseCode = "";
             try
             {
                 using (var httpClient = new HttpClient())
@@ -225,27 +232,29 @@ namespace Esfa.Roaao.Xslx.IntegrationTests
                     for (var i = 0; i <= 2; i++)
                     {
                         noofattempts = i + 1;
-                        var request = new HttpRequestMessage(HttpMethod.Head, new Uri(absolutePath));
+                        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(absolutePath));
                         request.Headers.Add("Accept", "text/html");
                         request.Headers.Add("Cache-Control", "no-cache");
                         request.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 6.2; WOW64; rv:19.0) Gecko/20100101 Firefox/19.0");
                         ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
-                        using (var response = httpClient.SendAsync(request))
+                        using (var response = await httpClient.SendAsync(request))
                         {
-                            var result = response.Result;
+                            var result = response;
+                            responseCode = result.StatusCode.ToString();
                             if (result.StatusCode == HttpStatusCode.OK)
                             {
-                                return new KeyValuePair<bool, int>(true, noofattempts);
+                                return new KeyValuePair<bool, string>(true, $"{noofattempts}");
                             }
                         }
+                        Thread.Sleep(300);
                     }
-                    return new KeyValuePair<bool, int>(false, noofattempts);
+                    return new KeyValuePair<bool, string>(false , $"{noofattempts} response {responseCode}");
                 }
             }
             catch (Exception)
             {
-                return new KeyValuePair<bool, int>(false, noofattempts);
+                return new KeyValuePair<bool, string>(false, $"{noofattempts}");
             }
         }
     }


### PR DESCRIPTION
Updated the test for the website link test, changed to be async await
and also changed it not to use HEAD but GET instead. Also added
response code to be returned for the result. Also made it so that the
blank URLs are not checked.